### PR TITLE
feat: Static libs for iOS and Android

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,7 +152,6 @@ jobs:
       - name: Remove unnecessary software
         if: runner.os == 'Linux'
         run: |
-          sudo rm -rf /usr/local/lib/android
           sudo rm -rf /opt/ghc
           sudo rm -rf /opt/hostedtoolcache/CodeQL
           sudo docker image prune --all --force

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,6 +155,10 @@ jobs:
           sudo rm -rf /opt/ghc
           sudo rm -rf /opt/hostedtoolcache/CodeQL
           sudo docker image prune --all --force
+      - name: Remove unnecessary software (non-Android)
+        if: runner.os == 'Linux' && matrix.target != 'aarch64-linux-android'
+        run: |
+          sudo rm -rf /usr/local/lib/android
       - uses: actions/checkout@v4
       - uses: seanmiddleditch/gha-setup-ninja@v6
       - uses: Jimver/cuda-toolkit@v0.2.23

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,7 +146,7 @@ jobs:
             runs-on: ubuntu-22.04
     steps:
       - name: Install cross-compile tools
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        if: matrix.target == 'aarch64-unknown-linux-gnu' || matrix.target == 'aarch64-linux-android'
         run: |
           sudo apt update && sudo apt install -y gcc make gcc-11-aarch64-linux-gnu g++-11-aarch64-linux-gnu binutils-aarch64-linux-gnu
       - name: Remove unnecessary software

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ env:
   NODE_VERSION: '18'
   XCODE_VERSION: '14.3.1'
   MACOSX_DEPLOYMENT_TARGET: '13.3'
+  IPHONEOS_DEPLOYMENT_TARGET: '15.1' # See: https://github.com/microsoft/onnxruntime/releases/tag/v1.21.0
+  ANDROID_API: '24' # See: https://github.com/microsoft/onnxruntime/releases/tag/v1.21.0
 jobs:
   build:
     name: Build
@@ -127,6 +129,21 @@ jobs:
             static: true
             feature-set: none
             runs-on: windows-2022
+          - target: aarch64-apple-ios
+            args: "-A aarch64 --iphoneos --xnnpack --coreml -N"
+            static: true
+            feature-set: none
+            runs-on: macos-13
+          - target: aarch64-apple-ios-sim
+            args: "-A aarch64 --iphonesimulator --xnnpack --coreml -N"
+            static: true
+            feature-set: none
+            runs-on: macos-13
+          - target: aarch64-linux-android
+            args: "-A aarch64 --android --xnnpack --nnapi -N"
+            static: true
+            feature-set: none
+            runs-on: ubuntu-22.04
     steps:
       - name: Install cross-compile tools
         if: matrix.target == 'aarch64-unknown-linux-gnu'
@@ -154,10 +171,25 @@ jobs:
       #     wget https://repo.radeon.com/amdgpu-install/6.1.1/ubuntu/jammy/amdgpu-install_6.1.60101-1_all.deb
       #     sudo apt install ./amdgpu-install_6.1.60101-1_all.deb -y
       #     DEBIAN_FRONTEND=noninteractive amdgpu-install --accept-eula -y --usecase=rocm,hiplibsdk --no-dkms
+      - uses: actions/setup-java@v4
+        if: matrix.target == 'aarch64-linux-android'
+        with:
+          java-version: "17"
+          distribution: "temurin"
+      - uses: android-actions/setup-android@v3
+        if: matrix.target == 'aarch64-linux-android'
+      - uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        if: matrix.target == 'aarch64-linux-android'
+        with:
+          add-to-path: false
+          ndk-version: r28
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
       - name: Run builder
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
         run:
           deno run -A src/build.ts -v ${{ inputs.onnxruntime-version }} ${{ matrix.static && '-s' || '' }} ${{ matrix.args }}
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
Hello 👋

I suggest to provide prebuilt onnxruntime libraries for iOS (`aarch64-apple-ios` and `aarch64-apple-ios-sim`) and Android (`aarch64-linux-android`) as part of `ort` to support most smartphones out-of-the-box.

Compilation of the three variants  of `onnxruntime` [already succeed](https://github.com/raphaelmenges/ort-artifacts-staging/actions/runs/17460801096). I successfully tested `aarch64-apple-ios` on my device. I am somehow struggling to link `aarch64-linux-android` and currently investigate the problem.

PS: I got my project also for `aarch64-linux-android` compiled and running. I cannot share that project, but highly suggest to create at least a minimal compilation or even better runtime test. Perhaps in the `ort` repository?